### PR TITLE
Movement fix / First Round Build Error

### DIFF
--- a/Buttons/Move.py
+++ b/Buttons/Move.py
@@ -37,7 +37,7 @@ class MoveButtons:
         view = View()
         originT = buttonID.split("_")[1]
         moveCount = buttonID.split("_")[2]
-        shipTypes = ["interceptor","cruiser","dread"]
+        shipTypes = ["interceptor","cruiser","dreadnought"]
         for shipType in shipTypes:
             player_color = player["color"]
             if f"{player_color}-{game.getShipShortName(shipType)}" in game.get_gamestate()["board"][originT]["player_ships"]:

--- a/Buttons/Move.py
+++ b/Buttons/Move.py
@@ -37,7 +37,7 @@ class MoveButtons:
         view = View()
         originT = buttonID.split("_")[1]
         moveCount = buttonID.split("_")[2]
-        shipTypes = ["interceptor","cruiser","dreadnought"]
+        shipTypes = ["interceptor","cruiser","dread"]
         for shipType in shipTypes:
             player_color = player["color"]
             if f"{player_color}-{game.getShipShortName(shipType)}" in game.get_gamestate()["board"][originT]["player_ships"]:

--- a/helpers/GamestateHelper.py
+++ b/helpers/GamestateHelper.py
@@ -296,6 +296,8 @@ class GamestateHelper:
 
         self.gamestate["players"][str(player_id)].update({"color": color})
         self.gamestate["players"][str(player_id)].update(faction_data[faction])
+        self.gamestate["players"][str(player_id)].update({"passed": False})
+        self.gamestate["players"][str(player_id)].update({"perma_passed": False})
         self.update()
         #return(f"{name} is now setup!")
 

--- a/helpers/ShipHelper.py
+++ b/helpers/ShipHelper.py
@@ -88,7 +88,7 @@ class PlayerShip(Ship):
             return "interceptor"
         elif ship == "cru":
             return "cruiser"
-        elif ship == "drd":
+        elif ship == "drd" or ship == "dreadnought":
             return "dread"
         elif ship == "sb":
             return "starbase"


### PR DESCRIPTION
Fixed the bug with moving Dreadnoughts. ShipHelper was being passed an unexpected name for dreads from movement buttons causing a key error with the player base ship stats. Adjusted the "ship_type_fixer" method to work with this instead of changing movement buttons and gamestate helper "getShortShipName" methods.

Also, discovered a bug with Build during the first round. It was checking for the "passed" flag however this is not being created until AFTER a player passes for the first time. Instead I've now added it on player creation so it exists form the beginning.