### PR TITLE
End of turn Population Cube Drop

### DIFF
--- a/Buttons/Build.py
+++ b/Buttons/Build.py
@@ -183,7 +183,9 @@ class BuildButtons:
         else:
             view2 = View()
             view2.add_item(Button(label="Build Somewhere Else", style=discord.ButtonStyle.red, custom_id="startBuild2"))  
-            view2.add_item(Button(label="End Turn", style=discord.ButtonStyle.red, custom_id="endTurn"))  
+            #view2.add_item(Button(label="End Turn", style=discord.ButtonStyle.red, custom_id="endTurn"))
+            view2.add_item(Button(label="Finish Action", style=discord.ButtonStyle.red,
+                                 custom_id=f"FCID{player['color']}_finishAction"))
             await interaction.channel.send(f"{interaction.user.mention} you could potentially build somewhere else.", view=view2)
         await interaction.message.delete()
         

--- a/Buttons/Explore.py
+++ b/Buttons/Explore.py
@@ -110,7 +110,8 @@ class ExploreButtons:
                 await DiscoveryTileButtons.exploreDiscoveryTile(game, msg[1],interaction,player)
         view = View()
         view.add_item(Button(label="Put Down Population", style=discord.ButtonStyle.gray, custom_id=f"FCID{player['color']}_startPopDrop"))
-        view.add_item(Button(label="End Turn", style=discord.ButtonStyle.red, custom_id=f"FCID{player['color']}_endTurn"))
+        #view.add_item(Button(label="End Turn", style=discord.ButtonStyle.red, custom_id=f"FCID{player['color']}_endTurn"))
+        view.add_item(Button(label="Finish Action", style=discord.ButtonStyle.red, custom_id=f"FCID{player['color']}_finishAction"))
         await interaction.channel.send(f"{interaction.user.mention} when you're finished resolving your action, you may end turn with this button.", view=view)
         await interaction.message.delete()
     @staticmethod
@@ -120,6 +121,9 @@ class ExploreButtons:
         await interaction.channel.send("Tile discarded")
         view = View()
         view.add_item(Button(label="Put Down Population", style=discord.ButtonStyle.gray, custom_id=f"FCID{player['color']}_startPopDrop"))
-        view.add_item(Button(label="End Turn", style=discord.ButtonStyle.red, custom_id=f"FCID{player['color']}_endTurn"))
-        await interaction.channel.send(f"{interaction.user.mention} when you're finished resolving your action, you may end turn with this button.", view=view)
+        #view.add_item(Button(label="End Turn", style=discord.ButtonStyle.red, custom_id=f"FCID{player['color']}_endTurn"))
+        view.add_item(Button(label="Finish Action", style=discord.ButtonStyle.red,
+                             custom_id=f"FCID{player['color']}_finishAction"))
+        await interaction.channel.send(f"{interaction.user.mention} when finished you may resolve your action "
+                                           f"with this button.", view=view)
         await interaction.message.delete()

--- a/Buttons/Influence.py
+++ b/Buttons/Influence.py
@@ -79,17 +79,24 @@ class InfluenceButtons:
         for button in view.children:
             if buttonID in button.custom_id:
                 view.remove_item(button)
-        await interaction.channel.send( f"{interaction.user.mention} now has "+str(numShips)+" colony ships available to use")
+        await interaction.response.send_message( f"{interaction.user.mention} now has "+str(numShips)+" colony ships "
+                                                                                               "available to use")
         await interaction.message.edit(view=view)
 
     @staticmethod
     async def finishInfluenceAction(game: GamestateHelper, player, interaction: discord.Interaction, player_helper:PlayerHelper):
         player_helper.spend_influence_on_action("influence")
         game.update_player(player_helper)
-        next_player = game.get_next_player(player)
-        view = TurnButtons.getStartTurnButtons(game, next_player)
+        view = View()
+        #next_player = game.get_next_player(player)
+        #view = TurnButtons.getStartTurnButtons(game, next_player)
         await interaction.message.delete()
-        await interaction.channel.send(f"{next_player['player_name']} use these buttons to do your turn. "+game.displayPlayerStats(next_player),view=view)
+        view.add_item(Button(label="Finish Action", style=discord.ButtonStyle.red,
+                             custom_id=f"FCID{player['color']}_finishAction"))
+        await interaction.channel.send(f"{interaction.user.mention} when finished you may resolve your action "
+                                       f"with this button.", view=view)
+        #await interaction.channel.send(f"{next_player['player_name']} use these buttons to do your turn.
+        # "+game.displayPlayerStats(next_player),view=view)
 
     @staticmethod
     async def removeInfluenceStart(game: GamestateHelper, player, interaction: discord.Interaction):

--- a/Buttons/Move.py
+++ b/Buttons/Move.py
@@ -102,8 +102,11 @@ class MoveButtons:
             await interaction.message.delete()
             view = View()
             view.add_item(Button(label="Move an additional ship", style=discord.ButtonStyle.green, custom_id=f"FCID{player['color']}_startMove_"+str(moveCount+1)))
-            view.add_item(Button(label="End Turn", style=discord.ButtonStyle.red, custom_id=f"FCID{player['color']}_endTurn"))
-            await interaction.channel.send(f"{interaction.user.mention} you can move an additional ship or end turn.", view=view)
+            view.add_item(Button(label="Finish Action", style=discord.ButtonStyle.red,
+                                 custom_id=f"FCID{player['color']}_finishAction"))
+            #view.add_item(Button(label="End Turn", style=discord.ButtonStyle.red, custom_id=f"FCID{player['color']}_endTurn"))
+            await interaction.channel.send(f"{interaction.user.mention} you can move an additional ship or end your "
+                                           f"action.", view=view)
         else:
             if player["move_apt"] == moveCount:
                 await TurnButtons.endTurn(player, game, interaction, bot)

--- a/Buttons/Research.py
+++ b/Buttons/Research.py
@@ -136,8 +136,11 @@ class ResearchButtons:
                 if buttonCount > 25:
                     await interaction.channel.send(view=view2)
             view = View()
-            view.add_item(Button(label="End Turn", style=discord.ButtonStyle.red, custom_id=f"FCID{player['color']}_endTurn"))
-            await interaction.channel.send(f"{interaction.user.mention} when you're finished resolving your action, you may end turn with this button.", view=view)
+            #view.add_item(Button(label="End Turn", style=discord.ButtonStyle.red, custom_id=f"FCID{player['color']}_endTurn"))
+            view.add_item(Button(label="Finish Action", style=discord.ButtonStyle.red,
+                                 custom_id=f"FCID{player['color']}_finishAction"))
+            await interaction.channel.send(f"{interaction.user.mention} when finished you may resolve your action "
+                                           f"with this button.", view=view)
 
     @staticmethod  
     async def getTech(game: GamestateHelper, player, player_helper: PlayerHelper, interaction: discord.Interaction, buttonID:str):

--- a/Buttons/Turn.py
+++ b/Buttons/Turn.py
@@ -9,9 +9,6 @@ import time
 import asyncio
 class TurnButtons:
 
-
-
-
     @staticmethod
     def noOneElsePassed(player, game: GamestateHelper):
         for p2 in game.get_gamestate()["players"]:
@@ -155,3 +152,13 @@ class TurnButtons:
         if game.get_gamestate()["player_count"] > 3:
             view.add_item(Button(label="Initiate Diplomatic Relations", style=discord.ButtonStyle.gray, custom_id=f"FCID{p1['color']}_startDiplomaticRelations"))
         return view
+
+    @staticmethod
+    async def finishAction(player, game:GamestateHelper, interaction: discord.Interaction):
+        view = View()
+        view.add_item(Button(label="End Turn", style=discord.ButtonStyle.red, custom_id=f"FCID{player['color']}_endTurn"))
+        if len(PopulationButtons.findEmptyPopulation(game, player)) > 0 and player["colony_ships"] > 0:
+            view.add_item(Button(label="Put Down Population", style=discord.ButtonStyle.gray, custom_id=f"FCID{player['color']}_startPopDrop"))
+        await interaction.response.send_message(f"Colony ships available: {player['colony_ships']}"
+                                                f"\nPlace population or end your turn.", view=view)
+        await interaction.message.delete()

--- a/Buttons/Upgrade.py
+++ b/Buttons/Upgrade.py
@@ -111,11 +111,14 @@ class UpgradeButtons:
             ships = ["interceptor","cruiser","dread","starbase"]
             for ship2 in ships:
                 view.add_item(Button(label=ship2.capitalize(), style=discord.ButtonStyle.blurple, custom_id=f"FCID{player['color']}_upgradeShip_{str(actions)}_{ship2}_dummy"))
-        view.add_item(Button(label="End Turn", style=discord.ButtonStyle.red, custom_id=f"FCID{player['color']}_endTurn"))
+        #view.add_item(Button(label="End Turn", style=discord.ButtonStyle.red, custom_id=f"FCID{player['color']}_endTurn"))
+        view.add_item(Button(label="Finish Action", style=discord.ButtonStyle.red,
+                             custom_id=f"FCID{player['color']}_finishAction"))
         await interaction.message.delete()
         await interaction.channel.send(f"{interaction.user.mention} replaced {part_stats[oldPart]['name']} with {part_stats[newPart]['name']} on their {ship.capitalize()} which now looks like this",file=drawing.show_player_ship_area(image))
         if discTileUpgrade == "dummy":
             await interaction.channel.send(
-                f"{interaction.user.mention}, choose which ship you would like to upgrade or end turn.", view=view)
+                f"{interaction.user.mention}, choose which ship you would like to upgrade or finish your action.",
+                view=view)
 
 

--- a/listeners/ButtonListener.py
+++ b/listeners/ButtonListener.py
@@ -143,6 +143,7 @@ class ButtonListener(commands.Cog):
             elapsed_time = end_time - start_time  
             if(elapsed_time > 2):
                 print(f"Total elapsed time for {customID} button press: {elapsed_time:.2f} seconds")  
-
+            if customID.startswith("finishAction"):
+                await TurnButtons.finishAction(player, game, interaction)
             
                 


### PR DESCRIPTION
All turn buttons now have an intermediate step before end turn is presented.

I new button called "Finish Action" is now called that reminds players they have colony ships and will allow them to drop population if possible. End turn is now presented here as well.

I adjusted the Influence buttons to go through this process as well. Previously it did not even hit End Turn steps but jumped directly to start turn which did not follow the same flow as any other buttons.

I tested most of the possible combinations here but someone else should probably run through a few before merging.