### PR TITLE
Fixed Sector 273 Advanced Material slot

### DIFF
--- a/data/sectors.json
+++ b/data/sectors.json
@@ -307,14 +307,14 @@
       190
     ],
     "material2_snap": [],
-    "materialadv_pop": [],
-    "materialadv1_snap": [
+    "materialadv_pop": [
       0
     ],
-    "materialadv2_snap": [
+    "materialadv1_snap": [
       305,
       190
     ],
+    "materialadv2_snap": [],
     "neutral_pop": [],
     "neutral1_snap": [],
     "neutral2_snap": [],


### PR DESCRIPTION
population count and coordinates were transposed down by one line, making it impossible to populate that cube slot.

Simple edit of a few lines.