### PR TITLE
Pass Rank On Button

### DIFF
--- a/Buttons/Turn.py
+++ b/Buttons/Turn.py
@@ -210,6 +210,11 @@ class TurnButtons:
         view = View()
         player = p1
         player_helper = PlayerHelper(game.getPlayersID(player), player)
+        number_passed = 0
+        ordinal = lambda n: "tsnrhtdd"[(n//10%10!=1)*(n%10<4)*n%10::4]
+        for p2 in game.get_gamestate()["players"]:
+            if "passed" in game.get_gamestate()["players"][p2] and game.get_gamestate()["players"][p2]["passed"] == True:
+                number_passed += 1
         if player["influence_discs"] != 0:
             if "passed" in p1 and p1["passed"]== True:
                 view.add_item(Button(label=f"Build (1)", style=discord.ButtonStyle.green, custom_id=f"FCID{player['color']}_startBuild"))
@@ -223,12 +228,12 @@ class TurnButtons:
                 view.add_item(Button(label=f"Upgrade ({p1['upgrade_apt']})", style=discord.ButtonStyle.blurple, custom_id=f"FCID{player['color']}_startUpgrade"))
                 view.add_item(Button(label=f"Move ({p1['move_apt']})", style=discord.ButtonStyle.green, custom_id=f"FCID{player['color']}_startMove"))
                 view.add_item(Button(label=f"Influence ({p1['influence_apt']})", style=discord.ButtonStyle.gray, custom_id=f"FCID{player['color']}_startInfluence"))
-                view.add_item(Button(label="Pass", style=discord.ButtonStyle.red, custom_id=f"FCID{p1['color']}_passForRound"))
+                view.add_item(Button(label=f"Pass {number_passed+1}{ordinal(number_passed+1)})", style=discord.ButtonStyle.red, custom_id=f"FCID{p1['color']}_passForRound"))
         else:
             if "passed" in p1 and p1["passed"]== True:
                 view.add_item(Button(label="Pass On Reaction", style=discord.ButtonStyle.red, custom_id=f"FCID{p1['color']}_passForRound"))
             else:
-                view.add_item(Button(label="Pass", style=discord.ButtonStyle.red, custom_id=f"FCID{p1['color']}_passForRound"))
+                view.add_item(Button(label=f"Pass {number_passed+1}{ordinal(number_passed+1)})", style=discord.ButtonStyle.red, custom_id=f"FCID{p1['color']}_passForRound"))
         view.add_item(Button(label="Show Game",style=discord.ButtonStyle.gray, custom_id="showGame"))
         view.add_item(Button(label="Show Reputation",style=discord.ButtonStyle.gray, custom_id="showReputation"))
         if len(PopulationButtons.findEmptyPopulation(game,p1)) > 0 and p1["colony_ships"] > 0:


### PR DESCRIPTION
This (should) add the ordinal for where a player ranks if they were to pass on the buttons for their turn. E.g. if no player has yet passed for the round, it would read `Pass (1st)`, if one player has passed, it would read `Pass (2nd)`, and so on. Ordinals are used to differentiate from the number of activations used on the action buttons. In regular Eclipse, it is useful to know if you'd be first to pass so as to get the 2 money and Start Player Tile. There's also the Turn Order Variant.