### PR TITLE
Draco disc tiles

### DIFF
--- a/Buttons/Draft.py
+++ b/Buttons/Draft.py
@@ -112,11 +112,11 @@ class DraftButtons:
         if faction == "ter4" or faction == "hyd":
             return "blue"
         if faction == "mag":
-            return "orange"
-        if faction == "lyr":
-            return "brown"
-        if faction == "rho":
             return "pink"
+        if faction == "lyr":
+            return "orange"
+        if faction == "rho":
+            return "brown"
         if faction == "exl":
             return "teal"
         return "green"

--- a/helpers/GamestateHelper.py
+++ b/helpers/GamestateHelper.py
@@ -1336,16 +1336,6 @@ class GamestateHelper:
         self.gamestate["board"][tile]["currentAction"] = action
         self.update()
 
-    def ai_eliminated(self, pos):
-        ships = self.gamestate["board"][pos]["player_ships"]
-        if len(ships) == 0:
-            return True
-        for i in ships:
-            if i.split("-")[0] == "ai":
-                return False
-        return True
-
-
     def get_system_coord(self, sector):
         for i in (self.gamestate["board"]):
             if self.gamestate["board"][i]["sector"] == sector:


### PR DESCRIPTION
Fixes some draco disc tile situations. Mainly if a player beats the ancients, but does not have neutron bombs it sends a reminder to the players to wait until after population bombing to determine who gets the discovery tile.

It is not fully automated and they will have to use a command in this scenario for now. But it prevents accidental giving to the wrong player automatically and they causing messy rewinds/rule confusion.