### PR TITLE
save game state at the start of the turn

### DIFF
--- a/Buttons/Turn.py
+++ b/Buttons/Turn.py
@@ -65,6 +65,7 @@ class TurnButtons:
             await interaction.channel.send("## " + game.getPlayerEmoji(nextPlayer) + " started their turn")
             await interaction.channel.send(f"{nextPlayer['player_name']} use buttons to do your turn"
                                            + game.displayPlayerStats(nextPlayer), view=view)
+            game.updateSaveFile()
         else:
             view = View()
             role = discord.utils.get(interaction.guild.roles, name=game.game_id)
@@ -135,6 +136,7 @@ class TurnButtons:
             await interaction.channel.send("## " + game.getPlayerEmoji(nextPlayer) + " started their turn")
             await interaction.channel.send(nextPlayer["player_name"] + " use buttons to do your turn"
                                            + game.displayPlayerStats(nextPlayer), view=view)
+            game.updateSaveFile()
             sendPermaPassButton = True
             
         else:

--- a/Buttons/Turn.py
+++ b/Buttons/Turn.py
@@ -296,6 +296,7 @@ class TurnButtons:
                 message = (f"{nextPlayer['player_name']} use buttons to do the first turn of the round" +
                            game.displayPlayerStats(nextPlayer))
                 await interaction.channel.send(message, view=view)
+                game.updateSaveFile()
             else:
                 await interaction.channel.send("Could not find first player, someone run /player start_turn")
         else:

--- a/listeners/ButtonListener.py
+++ b/listeners/ButtonListener.py
@@ -292,8 +292,6 @@ class ButtonListener(commands.Cog):
         elif customID.startswith("reducePopFor"):
             await DiplomaticRelationsButtons.reducePopFor(game, player_helper, interaction, customID)
         elif customID.startswith("startMove"):
-            if customID == "startMove":
-                game.updateSaveFile()
             await MoveButtons.startMove(game, player, interaction, customID, True)
         elif customID.startswith("moveFrom"):
             await MoveButtons.moveFrom(game, player, interaction, customID)
@@ -334,7 +332,6 @@ class ButtonListener(commands.Cog):
         elif customID.startswith("draftFaction"):
             await DraftButtons.draftFaction(game, interaction, customID)
         elif customID.startswith("pulsarAction"):
-            game.updateSaveFile()
             await PulsarButtons.pulsarAction(game, player, interaction, player_helper, customID)
         elif customID.startswith("blackHoleReturnStart"):
             await BlackHoleButtons.blackHoleReturnStart(game, player, customID, player_helper, interaction)

--- a/listeners/ButtonListener.py
+++ b/listeners/ButtonListener.py
@@ -175,7 +175,6 @@ class ButtonListener(commands.Cog):
         elif customID == "showReputation":
             await TurnButtons.showReputation(game, interaction, player)
         elif customID == "passForRound":
-            game.updateSaveFile()
             await TurnButtons.passForRound(player, game, interaction, player_helper)
         elif customID == "permanentlyPass":
             await TurnButtons.permanentlyPass(player, game, interaction, player_helper)
@@ -202,8 +201,6 @@ class ButtonListener(commands.Cog):
         elif customID.startswith("magColShipForSpentResource"):
             await TurnButtons.magColShipForSpentResource(game, interaction, player, customID, player_helper)
         elif customID.startswith("startExplore"):
-            if "2" not in customID:
-                game.updateSaveFile()
             await ExploreButtons.startExplore(game, player, player_helper, interaction, customID)
         elif customID.startswith("exploreTile"):
             await ExploreButtons.exploreTile(game, player, interaction, customID)
@@ -220,7 +217,6 @@ class ButtonListener(commands.Cog):
         elif customID.startswith("getFreeTech"):
             await DiscoveryTileButtons.getFreeTech(game, interaction, customID, player)
         elif customID.startswith("startResearch"):
-            game.updateSaveFile()
             await ResearchButtons.startResearch(game, player, player_helper, interaction, True)
         elif customID.startswith("getTech"):
             await ResearchButtons.getTech(game, player, player_helper, interaction, customID)
@@ -233,8 +229,6 @@ class ButtonListener(commands.Cog):
         elif customID.startswith("gain3resource"):
             await ResearchButtons.gain3resource(game, player, player_helper, interaction, customID)
         elif customID.startswith("startBuild"):
-            if "2" not in customID:
-                game.updateSaveFile()
             await BuildButtons.startBuild(game, player, interaction, customID, player_helper)
         elif customID.startswith("buildIn"):
             await BuildButtons.buildIn(game, player, interaction, customID)
@@ -249,7 +243,6 @@ class ButtonListener(commands.Cog):
         elif customID.startswith("finishSpendForBuild"):
             await BuildButtons.finishSpendForBuild(game, player, interaction, customID, player_helper)
         elif customID.startswith("startUpgrade"):
-            game.updateSaveFile()
             await UpgradeButtons.startUpgrade(game, player, interaction, True, "dummy","dum")
         elif customID.startswith("chooseDifferentShip"):
             actions = customID.split("_")[1]
@@ -267,7 +260,6 @@ class ButtonListener(commands.Cog):
         elif customID.startswith("fillPopulation"):
             await PopulationButtons.fillPopulation(game, player, interaction, customID)
         elif customID.startswith("startInfluence"):
-            game.updateSaveFile()
             await InfluenceButtons.startInfluence(game, player, interaction)
         elif customID.startswith("addInfluenceStart"):
             await InfluenceButtons.addInfluenceStart(game, player, interaction)
@@ -286,7 +278,6 @@ class ButtonListener(commands.Cog):
         elif customID.startswith("finishInfluenceAction"):
             await InfluenceButtons.finishInfluenceAction(game, player, interaction, player_helper)
         elif customID.startswith("startDiplomaticRelations"):
-            game.updateSaveFile()
             await DiplomaticRelationsButtons.startDiplomaticRelations(game, player, interaction)
         elif customID.startswith("startMinorRelations"):
             await DiplomaticRelationsButtons.startMinorRelations(game, player, interaction)


### PR DESCRIPTION
I'm playing a game as Wardens of Magellan and when I spend colony ships for resources/science/money before starting my action this does not get undone when I hit reset turn.

This happens because the state that the bot rolls back to is saved when one hits an action button. This PR instead saves the state at the start of the actual turn.

Having never contributed, I very much may have done something wrong here :)