### PR TITLE
Bugfix prevent after Planta explores and reveals tiles, prevent turn …

### DIFF
--- a/Buttons/Explore.py
+++ b/Buttons/Explore.py
@@ -115,6 +115,11 @@ class ExploreButtons:
         player = game.get_player(interaction.user.id,interaction)
         msg = customID.split("_")
         position = msg[1]
+        
+        # Lock turn restart because hidden layout information is being exposed
+        player["has_explored"] = True
+        game.update_player(PlayerHelper(game.getPlayersID(player), player))
+
         if len(msg) > 2:
             tileID = msg[2]
             game.tile_discard(msg[3])

--- a/Buttons/Turn.py
+++ b/Buttons/Turn.py
@@ -36,6 +36,14 @@ class TurnButtons:
 
     @staticmethod
     async def restartTurn(player, game: GamestateHelper, interaction: discord.Interaction):
+        # Enforce rule: No turn resets allowed after gaining tile information
+        if player.get("has_explored"):
+            await interaction.followup.send(
+                f"❌ {player['player_name']}, you cannot restart your turn after exploring and revealing a tile!",
+                ephemeral=True
+            )
+            return
+
         try:
             await interaction.message.delete()
             game.backUpToLastSaveFile()
@@ -55,6 +63,12 @@ class TurnButtons:
     async def endTurn(player, game: GamestateHelper, interaction: discord.Interaction):
         from helpers.CombatHelper import Combat
         nextPlayer = game.get_next_player(player)
+        
+        # Clear the exploration lockout flag when the turn successfully concludes
+        if player.get("has_explored"):
+            player["has_explored"] = False
+            game.update_player(PlayerHelper(game.getPlayersID(player), player))
+
         await game.updateNamesAndOutRimTiles(interaction)
         game.initilizeKey("20MinReminder")
         if nextPlayer is not None and not game.is_everyone_passed():


### PR DESCRIPTION
Description:

Planta faction has 2 explores. 
This Pull Request prevents "Restart turn" attempt after an explore action reveals tile.

Steps to Reproduce:

As a planta player, explore and reveal a tile.
Click restart.

Expected Behavior:

As a planta player, explore and reveal a tile.
After revealing a tile, it is expected that the player cannot "Restart turn" anymore.
