### PR TITLE
feat: implement cannot_restart turn reset lockout system

### DIFF
--- a/Buttons/Explore.py
+++ b/Buttons/Explore.py
@@ -115,6 +115,12 @@ class ExploreButtons:
         player = game.get_player(interaction.user.id,interaction)
         msg = customID.split("_")
         position = msg[1]
+
+        # Lock turn restart because of exposed hidden tile information.
+        player_helper = PlayerHelper(game.get_player_from_color(player['color']), player)
+        player_helper.setCannotRestart(True)
+        game.update_player(player_helper)
+
         if len(msg) > 2:
             tileID = msg[2]
             game.tile_discard(msg[3])

--- a/Buttons/Research.py
+++ b/Buttons/Research.py
@@ -111,6 +111,9 @@ class ResearchButtons:
             game.addDiscTile(game.getLocationFromID(player["home_planet"]))
             await DiscoveryTileButtons.exploreDiscoveryTile(game, game.getLocationFromID(player["home_planet"]),
                                                             interaction, player)
+            # Lock turn restart because of exposed hidden tile information.
+            player_helper.setCannotRestart(True)
+            game.update_player(player_helper)
         lenTech = len(player[f"{tech_type}_tech"])
         if lenTech == 4 and "magDiscTileUsed" in player and not player.get("magDiscTileUsed"):
             await interaction.channel.send(player["player_name"] + " due to researching your fourth tech"
@@ -119,6 +122,8 @@ class ResearchButtons:
             game.useMagDisc(str(interaction.user.id))
             await DiscoveryTileButtons.exploreDiscoveryTile(game, game.getLocationFromID(player["home_planet"]),
                                                             interaction, player)
+            player_helper.setCannotRestart(True)
+            game.update_player(player_helper)
 
     @staticmethod
     async def placeWarpPortal(interaction: discord.Interaction, game: GamestateHelper, player, customID):

--- a/Buttons/Turn.py
+++ b/Buttons/Turn.py
@@ -36,6 +36,15 @@ class TurnButtons:
 
     @staticmethod
     async def restartTurn(player, game: GamestateHelper, interaction: discord.Interaction):
+        player_helper = PlayerHelper(game.getPlayersID(player), player)
+        # Enforce rule: No turn resets allowed after gaining tile information
+        if player_helper.cannotRestart():
+            await interaction.followup.send(
+                f"❌ {player['player_name']}, you cannot restart your turn after revealing a tile!",
+                ephemeral=True
+            )
+            return
+
         try:
             await interaction.message.delete()
             game.backUpToLastSaveFile()
@@ -55,6 +64,12 @@ class TurnButtons:
     async def endTurn(player, game: GamestateHelper, interaction: discord.Interaction):
         from helpers.CombatHelper import Combat
         nextPlayer = game.get_next_player(player)
+
+        # Clear the restart lockout flag when the turn successfully concludes
+        player_helper = PlayerHelper(game.getPlayersID(player), player)
+        player_helper.setCannotRestart(False)
+        game.update_player(player_helper)
+
         await game.updateNamesAndOutRimTiles(interaction)
         game.initilizeKey("20MinReminder")
         if nextPlayer is not None and not game.is_everyone_passed():

--- a/commands/player_commands.py
+++ b/commands/player_commands.py
@@ -285,6 +285,19 @@ class PlayerCommands(commands.GroupCog, name="player"):
         game.update_player(player_helper)
         await interaction.response.send_message(f"{player.mention} set traitor status to {traitor}.")
 
+    @app_commands.command(name="set_cannot_restart")
+    async def set_cannot_restart(self, interaction: discord.Interaction, cannot_restart: bool,
+                          player: Optional[discord.Member] = None):
+        if player is None:
+            player = interaction.user
+        game = GamestateHelper(interaction.channel)
+        p1 = game.get_player(player.id,interaction)
+        player_helper = PlayerHelper(player.id, p1)
+        player_helper.setCannotRestart(cannot_restart)
+        game.update_player(player_helper)
+        await interaction.response.send_message(f"{player.mention} set cannot_restart status to {cannot_restart}.")
+
+
     @app_commands.command(name="draw_reputation")
     async def draw_reputation(self, interaction: discord.Interaction, num_options: int):
         game = GamestateHelper(interaction.channel)

--- a/helpers/PlayerHelper.py
+++ b/helpers/PlayerHelper.py
@@ -13,6 +13,12 @@ class PlayerHelper:
         else:
             return False
 
+    def cannotRestart(self):
+        if self.stats.get("cannot_restart"):
+            return True
+        else:
+            return False
+
     def adjust_materials(self, adjustment):
         before = self.stats["materials"]
         self.stats["materials"] += adjustment
@@ -131,6 +137,9 @@ class PlayerHelper:
 
     def setTraitor(self, traitor: bool):
         self.stats["traitor"] = traitor
+
+    def setCannotRestart(self, cannot_restart: bool):
+        self.stats["cannot_restart"] = cannot_restart
     
     def setEliminated(self, eliminated: bool):
         self.stats["eliminated"] = eliminated


### PR DESCRIPTION
# Title
`feat: Migrate turn reset lockout system to PlayerHelper methods`

## Description
A new property `cannot_restart` is added to the player's data model. Whenever an action is taken that reveals hidden or confidential gamestate information—such as making explicit exploration choices or pulling discovery tiles via research milestones—the turn is permanently locked for that round to preserve integrity and prevent unfair rollbacks.

---

## Key Changes

### 🛠️ Core Player Model & Helpers
* **`helpers/PlayerHelper.py`**
    * Added `cannotRestart()` getter to safely verify if a player is restricted from resetting.
    * Added `setCannotRestart(bool)` setter to manipulate the underlying `cannot_restart` state uniformly without exposing string keys across files.

### 🎮 Turn Lifecycle & Buttons

* **`Buttons/Turn.py`**
    * Updated `restartTurn` to call `player_helper.cannotRestart()`, throwing a clear, ephemeral layout failure block if triggered.
    * Updated `endTurn` to automatically clear the lockout state via `player_helper.setCannotRestart(False)` when the player finishes their round.
   
* **`Buttons/Explore.py`**

    * Injected `player_helper.setCannotRestart(True)` right at the start of resolution hooks to lock turn modification upon discovering sector layout data.
   
* **`Buttons/Research.py`**
    * Restricts turn restarts by invoking `player_helper.setCannotRestart(True)` whenever a standard tech discovery tile is drawn or when Magellan triggers their 4th tech track milestone discovery tile.

### 👑 Admin & Override Commands
* **`commands/player_commands.py`**
    * Exposed an optional admin slash command `/player set_cannot_restart [cannot_restart: bool] [player: Member]` to ease in-game tracking, edge case troubleshooting, or manual operator overrides.

### Notes

** This does not interfere or break with feature "Undo Last Turn"

---